### PR TITLE
Fix: permissions issue in the operator

### DIFF
--- a/charts/takeoff-operator/Dockerfile
+++ b/charts/takeoff-operator/Dockerfile
@@ -2,6 +2,7 @@
 FROM quay.io/operator-framework/helm-operator:v1.39.1
 
 ENV HOME=/opt/helm
-COPY watches.yaml ${HOME}/watches.yaml
-COPY helm-charts  ${HOME}/helm-charts
+COPY --chmod=777 watches.yaml ${HOME}/watches.yaml
+COPY --chmod=777 helm-charts  ${HOME}/helm-charts
+
 WORKDIR ${HOME}

--- a/charts/takeoff-operator/Makefile
+++ b/charts/takeoff-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.5
+VERSION ?= 0.0.7
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/charts/takeoff-operator/config/manager/kustomization.yaml
+++ b/charts/takeoff-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: tytn/operator
-  newTag: 0.0.5
+  newTag: 0.0.7

--- a/charts/takeoff/tests/application_test.yaml
+++ b/charts/takeoff/tests/application_test.yaml
@@ -32,6 +32,7 @@ tests:
                 internal_port: 3005
               readers_config:
                 hello-world-1:
+                  buffer_requests: true
                   consumer_group: primary
                   device: cpu
                   internal_gateway_ip: test-release-takeoff-controller
@@ -50,6 +51,7 @@ tests:
                 internal_port: 3005
               readers_config:
                 hello-world-2:
+                  buffer_requests: true
                   consumer_group: secondary
                   device: cuda
                   internal_gateway_ip: test-release-takeoff-controller

--- a/charts/takeoff/values.yaml
+++ b/charts/takeoff/values.yaml
@@ -185,6 +185,7 @@ applicationTemplate:
     modelName: "TitanML/dummy_model"
     device: "cpu"
     consumerGroup: "primary"
+    bufferRequests: true
     # accessToken: Option<String>, # The access token, to use when downloading from huggingface
     # logLevel: Option<String>, # The reader log level. Default is INFO
     # cudaVisibleDevices: Option<String>, # Comma separated list of cuda devices that should be visible to the reader. Defaults to the first one.


### PR DESCRIPTION
When the operator is run with `runAsRoot: false`, then we get an error like 'couldn't open `watches.yaml` file'. This makes `watches.yaml` world readable so that isn't the case.