### PR TITLE
fix: scale only on user supplied consumer groups

### DIFF
--- a/charts/takeoff/templates/applications.yaml
+++ b/charts/takeoff/templates/applications.yaml
@@ -243,13 +243,12 @@ scaleTargetRef:
 {{- $templateScalingSpec := fromYaml $scaledObjectTemplate }}
 
 {{- $consumerGroupKey := printf "target_%s" $mergedValues.readerConfig.consumerGroup }}
-{{- $readerIdKey := printf "target_%s" $appName }}
 {{- $serviceName := printf "%s-%s" (include "takeoff.fullname" $) $appName }}
 {{- $scalerAddress := printf "%s-controller.%s.svc.cluster.local:3005" (include "takeoff.fullname" $) $.Release.Namespace}}
 {{- $target := (toString $mergedValues.scaling.metricTarget.value)}}
 
 {{- $triggers := list }}
-  {{- $trigger := dict "type" "external-push" "metadata" (dict "scalerAddress" $scalerAddress $consumerGroupKey $target $readerIdKey $target) }}
+  {{- $trigger := dict "type" "external-push" "metadata" (dict "scalerAddress" $scalerAddress $consumerGroupKey $target) }}
   {{- $triggers = append $triggers $trigger }}
 
 {{- $specWithoutMetricTarget := omit $mergedValues.scaling.spec "metricTarget" }}

--- a/charts/takeoff/tests/application_test.yaml
+++ b/charts/takeoff/tests/application_test.yaml
@@ -139,7 +139,6 @@ tests:
             metadata:
               scalerAddress: test-release-takeoff-controller.test-namespace.svc.cluster.local:3005
               target_scalable: "15"
-              target_scaled-app: "15"
 
   - it: should configure ingress correctly when enabled
     documentSelector:

--- a/charts/takeoff/tests/merging_test.yaml
+++ b/charts/takeoff/tests/merging_test.yaml
@@ -34,9 +34,6 @@ tests:
           path: spec.triggers[0].metadata.scalerAddress
           value: test-release-takeoff-controller.test-namespace.svc.cluster.local:3005
       - equal:
-          path: spec.triggers[0].metadata.target_custom-scaled-app
-          value: "25"
-      - equal:
           path: spec.triggers[0].metadata.target_primary
           value: "25"
 
@@ -105,4 +102,3 @@ tests:
           content:
             name: custom-volume
             emptyDir: {}
-


### PR DESCRIPTION
I added scaling on the readerId key (which is an implicitly created consumer group). But this has some weird complications - because this key has the UUID behaviour, i can't do any scaling behaviour based on whether or not all the user's consumer groups exist or not.